### PR TITLE
fixed "iris-cli run react-typescript requires npm [BUG] #14".

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -86,6 +87,9 @@ func initCommand() *cobra.Command {
 			// Get go module path.
 			module := findModulePath(projectPath)
 
+			// Get the installed node package manager.
+			npmBin := findNpm()
+
 			p := &project.Project{
 				Name:               name,
 				Repo:               repo,
@@ -94,6 +98,7 @@ func initCommand() *cobra.Command {
 				Module:             module,
 				Files:              files, // if git repository then on unistall command the .git directory remains, if community wants to remove that too then will do.
 				NpmBuildScriptName: project.ActionBuild,
+				NodePackageManager: npmBin,
 			}
 
 			return p.SaveToDisk()
@@ -308,4 +313,24 @@ func getLatestTagFromRepository(repository *git.Repository) (string, error) {
 	}
 
 	return latestTagName, nil
+}
+
+// findNpm returns "npm" if installed,
+// otherwise "pnpm" if installed,
+// otherwise "yarn" if installed
+// otherwise "".
+func findNpm() string {
+	npmBin, err := exec.LookPath("npm")
+	if err == nil && npmBin != "" {
+		return npmBin
+	}
+	npmBin, err = exec.LookPath("pnpm")
+	if err == nil && npmBin != "" {
+		return npmBin
+	}
+	npmBin, err = exec.LookPath("yarn")
+	if err == nil && npmBin != "" {
+		return npmBin
+	}
+	return ""
 }

--- a/project/project.go
+++ b/project/project.go
@@ -39,6 +39,9 @@ type Project struct {
 	// Post installation.
 	// DisableInlineCommands disables source code comments stats with // $ _command_ to execute on "run" command.
 	DisableInlineCommands bool `json:"disable_inline_commands" yaml:"DisableInlineCommands" toml:"DisableInlineCommands"`
+	// NodePackageManager the node package manager to execute the npm commands.
+	// Defaults to "npm".
+	NodePackageManager string `json:"node_package_manager" yaml:"NodePackageManager" toml:"NodePackageManager"`
 	// DisableNpmInstall if `Run` and watch should NOT run npm install on first ran (and package.json changes).
 	// Defaults to false.
 	DisableNpmInstall bool `json:"disable_npm_install" yaml:"DisableNpmInstall" toml:"DisableNpmInstall"`
@@ -121,6 +124,10 @@ func (p *Project) setDefaults() {
 	}
 
 	p.frontEndRunningCommands = make(map[*exec.Cmd]context.CancelFunc) // make(chan context.CancelFunc, 20)
+
+	if p.NodePackageManager == "" {
+		p.NodePackageManager = "npm"
+	}
 }
 
 func (p *Project) SaveToDisk() error {
@@ -540,9 +547,11 @@ func (p *Project) build() error {
 		return nil
 	}
 
-	npmBin, err := exec.LookPath("npm")
+	npmBin, err := exec.LookPath(p.NodePackageManager)
 	if err != nil {
-		return fmt.Errorf("project <%s> requires nodejs to be installed", p.Name)
+		return fmt.Errorf(
+			"nodePackageManager in .iris.yml is set to %s, but %s could not be found",
+			p.NodePackageManager, p.NodePackageManager)
 	}
 
 	for _, f := range files {


### PR DESCRIPTION
### `iris-cli run react-typescript` can now run with npm, pnpm and yarn.

> This PR fixes this [issue](https://github.com/kataras/iris-cli/issues/14).